### PR TITLE
Fix KodiIdleTime

### DIFF
--- a/src/autosuspend/checks/activity.py
+++ b/src/autosuspend/checks/activity.py
@@ -132,9 +132,9 @@ class KodiIdleTime(NetworkMixin, Activity):
 
     def __init__(self, name: str, url: str, idle_time: int, **kwargs) -> None:
         request = url + \
-            '?request={"jsonrpc": "2.0", "id": 1, ' \
+            '?request={{"jsonrpc": "2.0", "id": 1, ' \
             '"method": "XBMC.GetInfoBooleans",' \
-            '"params": {"booleans": ["System.IdleTime({})"]}}'.format(
+            '"params": {{"booleans": ["System.IdleTime({})"]}}}}'.format(
                 idle_time)
         NetworkMixin.__init__(self, url=request, **kwargs)
         Activity.__init__(self, name)

--- a/src/autosuspend/checks/activity.py
+++ b/src/autosuspend/checks/activity.py
@@ -132,9 +132,9 @@ class KodiIdleTime(NetworkMixin, Activity):
 
     def __init__(self, name: str, url: str, idle_time: int, **kwargs) -> None:
         request = url + \
-            '?request={{"jsonrpc": "2.0", "id": 1, ' \
-            '"method": "XMBC.GetInfoBool"}},' \
-            '"params": {{"booleans": ["System.IdleTime({})"]}}'.format(
+            '?request={"jsonrpc": "2.0", "id": 1, ' \
+            '"method": "XBMC.GetInfoBooleans",' \
+            '"params": {"booleans": ["System.IdleTime({})"]}}'.format(
                 idle_time)
         NetworkMixin.__init__(self, url=request, **kwargs)
         Activity.__init__(self, name)


### PR DESCRIPTION
The request url returns a error message (parse error) in Kodi 18.1.
I've adapted the url according to this description on the Kodi website: https://kodi.wiki/view/JSON-RPC_API/v9#XBMC.GetInfoBooleans
and tested it on my kodi system.