### PR TITLE
Fix if clause in KodiIdleTime check

### DIFF
--- a/src/autosuspend/checks/activity.py
+++ b/src/autosuspend/checks/activity.py
@@ -143,7 +143,7 @@ class KodiIdleTime(NetworkMixin, Activity):
     def check(self):
         try:
             reply = self.request().json()
-            if reply['result']["System.IdleTime({})".format(self._idle_time)]:
+            if not reply['result']["System.IdleTime({})".format(self._idle_time)]:
                 return 'Someone interacts with Kodi'
             else:
                 return None

--- a/src/autosuspend/checks/activity.py
+++ b/src/autosuspend/checks/activity.py
@@ -143,7 +143,8 @@ class KodiIdleTime(NetworkMixin, Activity):
     def check(self):
         try:
             reply = self.request().json()
-            if not reply['result']["System.IdleTime({})".format(self._idle_time)]:
+            if not reply['result'][
+                    "System.IdleTime({})".format(self._idle_time)]:
                 return 'Someone interacts with Kodi'
             else:
                 return None

--- a/tests/test_checks_activity.py
+++ b/tests/test_checks_activity.py
@@ -741,7 +741,7 @@ class TestKodiIdleTime(CheckTest):
         mock_reply = mocker.MagicMock()
         mock_reply.json.return_value = {"id": 1, "jsonrpc": "2.0",
                                         "result": {
-                                            "System.IdleTime(42)": True}}
+                                            "System.IdleTime(42)": False}}
         mocker.patch('requests.Session.get', return_value=mock_reply)
 
         assert KodiIdleTime('foo', url='url',
@@ -751,7 +751,7 @@ class TestKodiIdleTime(CheckTest):
         mock_reply = mocker.MagicMock()
         mock_reply.json.return_value = {"id": 1, "jsonrpc": "2.0",
                                         "result": {
-                                            "System.IdleTime(42)": False}}
+                                            "System.IdleTime(42)": True}}
         mocker.patch('requests.Session.get', return_value=mock_reply)
 
         assert KodiIdleTime('foo', url='url',


### PR DESCRIPTION
Kodi sets the Idle boolean to ```true``` when the given time in ```System.IdleTime(x)``` runs out and the user wasn't active for this amount of time. Hence the user is active when the returned boolean is ```false```.
I've updated the if clause according to this observation.