### PR TITLE
Fix IdleHint checking in LogindSessionsIdle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
-      - name: Install dbus
-        run: sudo apt-get -y install libdbus-1-dev
+      - name: Install native dependencies
+        run: sudo apt-get -y install libdbus-1-dev libgirepository1.0-dev
       - name: Install tox
         run: |
           python -m pip install --upgrade pip
@@ -35,8 +35,8 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
-      - name: Install dbus
-        run: sudo apt-get -y install libdbus-1-dev
+      - name: Install native dependencies
+        run: sudo apt-get -y install libdbus-1-dev libgirepository1.0-dev
       - name: Install tox
         run: |
           python -m pip install --upgrade pip
@@ -76,8 +76,8 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dbus
-        run: sudo apt-get -y install libdbus-1-dev
+      - name: Install native dependencies
+        run: sudo apt-get -y install libdbus-1-dev libgirepository1.0-dev
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ extras_require = {
         'pytest-mock',
         'freezegun',
         'pytest-freezegun',
+        'python-dbusmock',
+        'PyGObject',
     ],
 }
 extras_require['test'].extend(

--- a/src/autosuspend/checks/activity.py
+++ b/src/autosuspend/checks/activity.py
@@ -704,7 +704,7 @@ class LogindSessionsIdle(Activity):
 
             if properties['Type'] not in self._types:
                 self.logger.debug('Ignoring session of wrong type %s',
-                                  properties['type'])
+                                  properties['Type'])
                 continue
             if properties['State'] not in self._states:
                 self.logger.debug('Ignoring session because its state is %s',

--- a/src/autosuspend/checks/activity.py
+++ b/src/autosuspend/checks/activity.py
@@ -711,7 +711,7 @@ class LogindSessionsIdle(Activity):
                                   properties['State'])
                 continue
 
-            if properties['IdleHint'] == 'no':
+            if not properties['IdleHint']:
                 return 'Login session {} is not idle'.format(
                     session_id)
 

--- a/src/autosuspend/util/systemd.py
+++ b/src/autosuspend/util/systemd.py
@@ -1,4 +1,13 @@
-from typing import Iterable, Tuple
+from typing import Iterable, Tuple, TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    import dbus
+
+
+def _get_bus() -> 'dbus.SystemBus':
+    import dbus
+    return dbus.SystemBus()
 
 
 def list_logind_sessions() -> Iterable[Tuple[str, dict]]:
@@ -10,7 +19,7 @@ def list_logind_sessions() -> Iterable[Tuple[str, dict]]:
             represented as dicts.
     """
     import dbus
-    bus = dbus.SystemBus()
+    bus = _get_bus()
     login1 = bus.get_object("org.freedesktop.login1",
                             "/org/freedesktop/login1")
 

--- a/tests/test_checks_activity.py
+++ b/tests/test_checks_activity.py
@@ -1161,17 +1161,26 @@ class TestLogindSessionsIdle(CheckTest):
         return LogindSessionsIdle(
             name, ['tty', 'x11', 'wayland'], ['active', 'online'])
 
-    def test_smoke(self) -> None:
+    def test_active(self, logind) -> None:
+        logind.AddSession('c1', 'seat0', 1042, 'auser', True)
+
         check = LogindSessionsIdle(
-            'test', ['tty', 'x11', 'wayland'], ['active', 'online'])
-        assert check._types == ['tty', 'x11', 'wayland']
-        assert check._states == ['active', 'online']
-        try:
-            # only run the test if the dbus module is available (not on travis)
-            import dbus  # noqa: F401
-            check.check()
-        except ImportError:
-            pass
+            'test', ['test'], ['active', 'online'])
+        check.check() is not None
+
+    def test_inactive(self, logind) -> None:
+        logind.AddSession('c1', 'seat0', 1042, 'auser', False)
+
+        check = LogindSessionsIdle(
+            'test', ['test'], ['active', 'online'])
+        check.check() is None
+
+    def test_ignore_unknow_type(self, logind) -> None:
+        logind.AddSession('c1', 'seat0', 1042, 'auser', True)
+
+        check = LogindSessionsIdle(
+            'test', ['not_test'], ['active', 'online'])
+        check.check() is None
 
     def test_configure_defaults(self) -> None:
         parser = configparser.ConfigParser()

--- a/tests/test_util_systemd.py
+++ b/tests/test_util_systemd.py
@@ -1,9 +1,10 @@
-import pytest
-
 from autosuspend.util.systemd import list_logind_sessions
 
 
-def test_list_logind_sessions() -> None:
-    pytest.importorskip('dbus')
+def test_list_logind_sessions_empty(logind) -> None:
+    assert len(list(list_logind_sessions())) == 0
 
-    assert list_logind_sessions() is not None
+    logind.AddSession('c1', 'seat0', 1042, 'auser', True)
+    sessions = list(list_logind_sessions())
+    assert len(sessions) == 1
+    assert sessions[0][0] == 'c1'


### PR DESCRIPTION
IdleHint is a boolean value in DBus schema
(https://www.freedesktop.org/wiki/Software/systemd/logind/),
it will have a falsy value, not "no" as a string when the session is not
idle.

Fixes #71.