### PR TITLE
Improve error handling and make it consistent

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -27,6 +27,7 @@ Notable changes
 * The required `Python`_ version is now declared in the :ref:`installation` and :file:`setup.py` (:issue:`76`)
 * Python 3.9 is officially supported and tested (:issue:`89`).
 * Some code cleanup work has been performed (:issue:`93` and :issue:`92`).
+* The daemon now better distinguished between temporary and permanent issues, for instance, by terminating in case a required program is not installed (:issue:`78`).
 
 3.0
 ***

--- a/src/autosuspend/checks/__init__.py
+++ b/src/autosuspend/checks/__init__.py
@@ -15,7 +15,8 @@ class ConfigurationError(RuntimeError):
 
 
 class TemporaryCheckError(RuntimeError):
-    """Indicates a temporary error while performing a check.
+    """
+    Indicates a temporary error while performing a check.
 
     Such an error can be ignored for some time since it might recover
     automatically.
@@ -25,9 +26,10 @@ class TemporaryCheckError(RuntimeError):
 
 
 class SevereCheckError(RuntimeError):
-    """Indicates a sever check error that will probably not recover.
+    """
+    Indicates a sever check error that will probably not recover.
 
-    There no hope this situation recovers.
+    There is no hope this situation recovers.
     """
 
     pass

--- a/src/autosuspend/util/subprocess.py
+++ b/src/autosuspend/util/subprocess.py
@@ -1,0 +1,9 @@
+import subprocess
+
+from ..checks import SevereCheckError
+
+
+def raise_severe_if_command_not_found(error: subprocess.CalledProcessError) -> None:
+    if error.returncode == 127:
+        # see http://tldp.org/LDP/abs/html/exitcodes.html
+        raise SevereCheckError(f"Command '{' '.join(error.cmd)}' does not exist")

--- a/tests/test_checks_wakeup.py
+++ b/tests/test_checks_wakeup.py
@@ -8,7 +8,12 @@ import dateutil.parser
 import pytest
 from pytest_mock import MockFixture
 
-from autosuspend.checks import Check, ConfigurationError, TemporaryCheckError
+from autosuspend.checks import (
+    Check,
+    ConfigurationError,
+    SevereCheckError,
+    TemporaryCheckError,
+)
 from autosuspend.checks.wakeup import (
     Calendar,
     Command,
@@ -205,6 +210,11 @@ class TestCommand(CheckTest):
         mock.side_effect = subprocess.CalledProcessError(2, "foo bar")
         check = Command("test", "echo bla")
         with pytest.raises(TemporaryCheckError):
+            check.check(datetime.now(timezone.utc))
+
+    def test_missing_executable(self, mocker: MockFixture) -> None:
+        check = Command("test", "reallydoesntexist bla")
+        with pytest.raises(SevereCheckError):
             check.check(datetime.now(timezone.utc))
 
 


### PR DESCRIPTION
* Ensure that errors that cannot be recovered are correctly classified
  as SevereCheckErrors while others are consistently reported as
  TemporaryCheckErrors.
* Catch some special cases such as missing binaries to execute and
  report them as SevereCheckErrors.
* Always provide a custom explanation in reported exceptions.