### PR TITLE
Explain from-source installation with extras and branch

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -71,6 +71,18 @@ Briefly, the following steps can be used to install |project_program| from sourc
 .. code-block:: bash
 
    python3 -m venv /opt/autosuspend
-   /opt/autosuspend/bin/pip install git+https://github.com/languitar/autosuspend.git
+   /opt/autosuspend/bin/pip install git+https://github.com/languitar/autosuspend.git@<tag or branch>#egg=autosuspend[all]
+
+.. note::
+
+   Replace the angle brackets with desired Git tag or branch.
+   Use ``master`` for the latest development release.
+
+.. note::
+
+   The ``all`` in the square brackets ensures that |project_program| is installed with all optional dependencies.
+   That way all available checks can be used.
+   In case you only need a subset of optional requirements, replace ``all`` with a comma-separated list of package extras.
+   The names of these extras can be found in :file:`setup.py`.
 
 Afterwards, copy the systemd_ unit files found in ``/opt/autosuspend/lib/systemd/system/`` to ``/etc/systemd`` and adapt the contained paths to the installation location.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 name = "autosuspend"
 
-version_file = (Path(__file__).absolute().parent / "VERSION")
+version_file = Path(__file__).absolute().parent / "VERSION"
 lines = version_file.read_text().splitlines()
 release = lines[1].strip()
 
@@ -30,6 +30,9 @@ extras_require = {
     ],
 }
 extras_require["test"].extend(
+    {dep for k, v in extras_require.items() if k != "test" for dep in v},
+)
+extras_require["all"] = list(
     {dep for k, v in extras_require.items() if k != "test" for dep in v},
 )
 


### PR DESCRIPTION
Include an `all` package extra and use that one by default for the
from-source installation such that users receive all additional
requirements.

This provides the required installation instructions for testing #99 