### PR TITLE
fix: use jsonpath ext to support filter expressions

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -14,7 +14,7 @@ New features
 New activity checks
 -------------------
 
-* :ref:`check-jsonpath`: Similar to the existing :ref`check-xpath`, the new checks requests a JSON URL and evaluates it against a `JSONPath`_ expression to determine activity (:issue:`81`).
+* :ref:`check-jsonpath`: Similar to the existing :ref`check-xpath`, the new checks requests a JSON URL and evaluates it against a `JSONPath`_ expression to determine activity (:issue:`81`, :issue:`103`).
 * :ref:`check-last-log-activity`: Check log files for most recent contained timestamps (:issue:`98`, :issue:`99`).
 
 Fixed bugs

--- a/src/autosuspend/checks/activity.py
+++ b/src/autosuspend/checks/activity.py
@@ -749,7 +749,7 @@ class JsonPath(NetworkMixin, Activity):
 
     @classmethod
     def collect_init_args(cls, config: configparser.SectionProxy) -> Dict[str, Any]:
-        from jsonpath_ng import parse
+        from jsonpath_ng.ext import parse
 
         try:
             args = NetworkMixin.collect_init_args(config)

--- a/tests/test_checks_activity.py
+++ b/tests/test_checks_activity.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Dict, Tuple
 
 from dbus.proxies import ProxyObject
 from freezegun import freeze_time
-from jsonpath_ng import parse
+from jsonpath_ng.ext import parse
 import mpd
 import psutil
 import pytest
@@ -1455,6 +1455,20 @@ class TestJsonPath(CheckTest):
         url = "nourl"
         assert (
             JsonPath("foo", jsonpath=parse("a.b"), url=url, timeout=5).check()
+            is not None
+        )
+
+        json_get_mock.assert_called_once_with(
+            url, timeout=5, headers={"Accept": "application/json"}
+        )
+        json_get_mock().json.assert_called_once()
+
+    def test_filter_expressions_work(self, json_get_mock: Any) -> None:
+        url = "nourl"
+        assert (
+            JsonPath(
+                "foo", jsonpath=parse("$[?(@.c=='ignore')]"), url=url, timeout=5
+            ).check()
             is not None
         )
 


### PR DESCRIPTION
Change the jsonpath parser to the ext module which provides support for
filter expressions.

Related to #102