### PR TITLE
docs: new section with ExternalCommand user scripts

### DIFF
--- a/doc/source/available_checks.rst
+++ b/doc/source/available_checks.rst
@@ -80,6 +80,10 @@ In case this command returns 0, the system is assumed to be active.
 The command is executed as is using shell execution.
 Beware of malicious commands in obtained configuration files.
 
+.. seealso::
+
+   * :ref:`external-command-activity-scripts` for a collection of user-provided scripts for some common use cases.
+
 Options
 =======
 

--- a/doc/source/external_command_activity_scripts.rst
+++ b/doc/source/external_command_activity_scripts.rst
@@ -1,0 +1,29 @@
+.. _external-command-activity-scripts:
+
+External command scripts for activity detection
+###############################################
+
+A collection of user-provided scripts to use with the :ref:`check-external-command` check for activity detection.
+
+pyLoad
+******
+
+`pyLoad <https://pyload.net/>`_ uses an uncommon login theme for its API and hence two separate requests are required to query for active downloads.
+Use something along the following lines to query `pyLoad`_.
+
+.. code-block:: bash
+
+   #!/bin/bash
+
+   SessionID=$(curl -s "http://127.0.0.1:8000/api/login" -g -H "Host: 127.0.0.1:8000" -H "Content-Type: application/x-www-form-urlencoded" --data "username=user&password=password" | jq -r)
+
+   SessionStatus=$(curl -s  "http://127.0.0.1:8000/api/statusServer" -g -H "Host: 127.0.0.1:8000" -H "Content-Type: application/x-www-form-urlencoded" --data "session=$SessionID" | jq -r '.active')
+
+   if [ $SessionStatus -eq 1 ]
+   then
+     exit 0
+   else
+     exit 1
+   fi
+
+Source: :issue:`102`

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -6,10 +6,10 @@ Frequently Asked Questions
 Usage
 *****
 
-How do I add custom checks?
-===========================
+How to check unsupported software?
+==================================
 
-Two options:
+In case you want to detect if some piece of software running on your system that is not officially supported is performing relevant activity you have two options:
 
 * Use a script with the :ref:`check-external-command` check.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -76,6 +76,7 @@ The following diagram visualizes the periodic processing performed by |project|.
    available_checks
    available_wakeups
    systemd_integration
+   external_command_activity_scripts
    api
 
 .. toctree::


### PR DESCRIPTION
Adds the pyLoad user script from #102 to a new section with
user-provided scripts.

Some more clarifying words in the FAQ regarding this case are added here
too.