### PR TITLE
fix(ical): support tzlocal 3.0

### DIFF
--- a/src/autosuspend/util/ical.py
+++ b/src/autosuspend/util/ical.py
@@ -118,7 +118,7 @@ def _expand_rrule(
     # expand the rrule
     dates = []
     for candidate in rules.between(start_at - instance_duration, end_at, inc=True):
-        localized = orig_tz.localize(candidate)  # type: ignore
+        localized = candidate.astimezone(orig_tz)
         dates.append(localized)
     return dates
 
@@ -224,9 +224,9 @@ def _extract_events_from_component(
     # datetimes.
     if isinstance(start, datetime) and not is_aware(start):
         assert not is_aware(end)
-        local_time = tzlocal.get_localzone()
-        start = local_time.localize(start)
-        end = local_time.localize(end)
+        local_zone = tzlocal.get_localzone()
+        start = start.astimezone(local_zone)
+        end = end.astimezone(local_zone)
 
     if component.get("rrule"):
         return _extract_events_from_recurring_component(


### PR DESCRIPTION
tzlocal 3.0 has converted to the new Python 3.9 zoneinfo library as the
timezone provider. These timezone instances do not have the py-tz
specific localize function. Therefore, convert to the standard library
astimezone function, which exists for pytz, too.