### PR TITLE
fix(ical): limit tzlocal to version <3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extras_require = {
     "XPath": ["lxml", "requests"],
     "JSONPath": ["jsonpath-ng", "requests"],
     "Logind": ["dbus-python"],
-    "ical": ["requests", "icalendar", "python-dateutil", "tzlocal"],
+    "ical": ["requests", "icalendar", "python-dateutil", "tzlocal<3"],
     "localfiles": ["requests-file"],
     "logactivity": ["python-dateutil", "pytz"],
     "test": [


### PR DESCRIPTION
tzlocal 3 has switched from pytz to zoneinfo as the timezone provider.
This has some strange side-effects that still need to be investigated.
As a temporary workaround, limit tzlocal to versions below 3. The
maintainer of tzlocal has indicated that the 2.x release line will be
supported for some time still.