### PR TITLE
fix(activity): detect ipv4 mapped ipv6 connections

### DIFF
--- a/tests/test_checks_activity.py
+++ b/tests/test_checks_activity.py
@@ -345,6 +345,17 @@ class TestActiveConnection(CheckTest):
                 "ESTABLISHED",
                 None,
             ),
+            # ipv6 with mapping to ipv4
+            # https://github.com/languitar/autosuspend/issues/116
+            psutil._common.sconn(
+                -1,
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                (f"::ffff:{MY_ADDRESS}", MY_PORT),
+                ("42.42.42.42", 42),
+                "ESTABLISHED",
+                None,
+            ),
         ],
     )
     def test_connected(


### PR DESCRIPTION
In the ActiveConnection check, properly handle the case where a service
listening on an IPv4 address is targeted by an IPv6 connection that
uses the special IPv6 range for mapping towards IPv4 addresses. This is
realized by transforming all IPv4 addresses into the IPv6 space.
Hopefully, this catches all corner-cases.

Fixes: #116