### PR TITLE
fix(ical): support tzlocal >= 4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extras_require = {
     "XPath": ["lxml", "requests"],
     "JSONPath": ["jsonpath-ng", "requests"],
     "Logind": ["dbus-python"],
-    "ical": ["requests", "icalendar", "python-dateutil", "tzlocal<3"],
+    "ical": ["requests", "icalendar", "python-dateutil", "tzlocal!=3.0"],
     "localfiles": ["requests-file"],
     "logactivity": ["python-dateutil", "pytz"],
     "test": [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,test-py38-psutil{55,latest}-dateutil{27,latest}, test-py39-psutillatest-dateutillatest, test-py310-psutillatest-dateutillatest, integration-py{38,39,310}, mindeps, check, docs, coverage
+envlist = coverage-clean,test-py38-psutil55-dateutil27-tzlocal2, test-py{39,310}-psutillatest-dateutillatest-tzlocallatest, integration-py{38,39,310}, mindeps, check, docs, coverage
 
 [testenv]
 extras = test
@@ -10,6 +10,8 @@ deps =
     psutillatest: psutil
     dateutil27: python-dateutil>=2.7,<2.8
     dateutillatest: python-dateutil
+    tzlocal2: tzlocal<3
+    tzlocallatest: tzlocal>3
 commands =
     {envbindir}/python -V
     {envbindir}/python -c 'import psutil; print(psutil.__version__)'


### PR DESCRIPTION
tzlocal 3.0 has converted to the new Python 3.9 zoneinfo library as the
timezone provider. These timezone instances do not have the pytz
specific localize function. Therefore, tzlocal was pinned to versions < 3. With a compatibility layer now in place starting with tzlocal 4, this pinning isn't needed anymore.