### PR TITLE
refactor: extract systemd checks into own module

### DIFF
--- a/src/autosuspend/checks/systemd.py
+++ b/src/autosuspend/checks/systemd.py
@@ -1,0 +1,115 @@
+import configparser
+from datetime import datetime, timedelta, timezone
+import re
+from typing import Dict, Iterable, Optional, Pattern, Tuple
+
+import dbus
+
+from . import Activity, ConfigurationError, TemporaryCheckError, Wakeup
+from ..util.systemd import list_logind_sessions, LogindDBusException
+
+
+def next_timer_executions() -> Dict[str, datetime]:
+    bus = dbus.SystemBus()
+
+    systemd = bus.get_object("org.freedesktop.systemd1", "/org/freedesktop/systemd1")
+    units = systemd.ListUnits(dbus_interface="org.freedesktop.systemd1.Manager")
+    timers = [unit for unit in units if unit[0].endswith(".timer")]
+
+    result: Dict[str, datetime] = {}
+    for timer in timers:
+        obj = bus.get_object("org.freedesktop.systemd1", timer[6])
+        properties_interface = dbus.Interface(obj, "org.freedesktop.DBus.Properties")
+        props = properties_interface.GetAll("org.freedesktop.systemd1.Timer")
+
+        next_time: Optional[datetime] = None
+        if props["NextElapseUSecRealtime"]:
+            next_time = datetime.fromtimestamp(
+                props["NextElapseUSecRealtime"] / 1000000,
+                tz=timezone.utc,
+            )
+        elif props["NextElapseUSecMonotonic"]:
+            next_time = datetime.now(tz=timezone.utc) + timedelta(
+                seconds=props["NextElapseUSecMonotonic"] / 1000000
+            )
+
+        if next_time:
+            result[str(timer[0])] = next_time
+
+    return result
+
+
+class SystemdTimer(Wakeup):
+    """Ensures that the system is active when some selected SystemD timers will run."""
+
+    @classmethod
+    def create(cls, name: str, config: configparser.SectionProxy) -> "SystemdTimer":
+        try:
+            return cls(name, re.compile(config["match"]))
+        except (re.error, ValueError, KeyError, TypeError) as error:
+            raise ConfigurationError(str(error))
+
+    def __init__(self, name: str, match: Pattern) -> None:
+        Wakeup.__init__(self, name)
+        self._match = match
+
+    def check(self, timestamp: datetime) -> Optional[datetime]:
+        executions = next_timer_executions()
+        matching_executions = [
+            next_run for name, next_run in executions.items() if self._match.match(name)
+        ]
+        try:
+            return min(matching_executions)
+        except ValueError:
+            return None
+
+
+class LogindSessionsIdle(Activity):
+    """Prevents suspending in case a logind session is marked not idle.
+
+    The decision is based on the ``IdleHint`` property of logind sessions.
+    """
+
+    @classmethod
+    def create(
+        cls,
+        name: str,
+        config: configparser.SectionProxy,
+    ) -> "LogindSessionsIdle":
+        types = config.get("types", fallback="tty,x11,wayland").split(",")
+        types = [t.strip() for t in types]
+        states = config.get("states", fallback="active,online").split(",")
+        states = [t.strip() for t in states]
+        return cls(name, types, states)
+
+    def __init__(self, name: str, types: Iterable[str], states: Iterable[str]) -> None:
+        Activity.__init__(self, name)
+        self._types = types
+        self._states = states
+
+    @staticmethod
+    def _list_logind_sessions() -> Iterable[Tuple[str, dict]]:
+        try:
+            return list_logind_sessions()
+        except LogindDBusException as error:
+            raise TemporaryCheckError(error) from error
+
+    def check(self) -> Optional[str]:
+        for session_id, properties in self._list_logind_sessions():
+            self.logger.debug("Session %s properties: %s", session_id, properties)
+
+            if properties["Type"] not in self._types:
+                self.logger.debug(
+                    "Ignoring session of wrong type %s", properties["Type"]
+                )
+                continue
+            if properties["State"] not in self._states:
+                self.logger.debug(
+                    "Ignoring session because its state is %s", properties["State"]
+                )
+                continue
+
+            if not properties["IdleHint"]:
+                return "Login session {} is not idle".format(session_id)
+
+        return None

--- a/src/autosuspend/util/systemd.py
+++ b/src/autosuspend/util/systemd.py
@@ -1,5 +1,4 @@
-from datetime import datetime, timedelta, timezone
-from typing import Dict, Iterable, Optional, Tuple, TYPE_CHECKING
+from typing import Iterable, Tuple, TYPE_CHECKING
 
 
 if TYPE_CHECKING:
@@ -44,35 +43,3 @@ def list_logind_sessions() -> Iterable[Tuple[str, dict]]:
         raise LogindDBusException(error) from error
 
     return results
-
-
-def next_timer_executions() -> Dict[str, datetime]:
-    import dbus
-
-    bus = _get_bus()
-
-    systemd = bus.get_object("org.freedesktop.systemd1", "/org/freedesktop/systemd1")
-    units = systemd.ListUnits(dbus_interface="org.freedesktop.systemd1.Manager")
-    timers = [unit for unit in units if unit[0].endswith(".timer")]
-
-    result: Dict[str, datetime] = {}
-    for timer in timers:
-        obj = bus.get_object("org.freedesktop.systemd1", timer[6])
-        properties_interface = dbus.Interface(obj, "org.freedesktop.DBus.Properties")
-        props = properties_interface.GetAll("org.freedesktop.systemd1.Timer")
-
-        next_time: Optional[datetime] = None
-        if props["NextElapseUSecRealtime"]:
-            next_time = datetime.fromtimestamp(
-                props["NextElapseUSecRealtime"] / 1000000,
-                tz=timezone.utc,
-            )
-        elif props["NextElapseUSecMonotonic"]:
-            next_time = datetime.now(tz=timezone.utc) + timedelta(
-                seconds=props["NextElapseUSecMonotonic"] / 1000000
-            )
-
-        if next_time:
-            result[str(timer[0])] = next_time
-
-    return result

--- a/tests/test_checks_systemd.py
+++ b/tests/test_checks_systemd.py
@@ -1,0 +1,65 @@
+from datetime import datetime, timedelta, timezone
+import re
+from unittest.mock import Mock
+
+import pytest
+from pytest_mock import MockFixture
+
+from autosuspend.checks import Check, ConfigurationError
+from autosuspend.checks.systemd import next_timer_executions, SystemdTimer
+
+from . import CheckTest
+from .utils import config_section
+
+
+@pytest.mark.skip(reason="No dbusmock implementation available")
+def test_next_timer_executions() -> None:
+    assert next_timer_executions() is not None
+
+
+class TestSystemdTimer(CheckTest):
+    @staticmethod
+    @pytest.fixture()
+    def next_timer_executions(mocker: MockFixture) -> Mock:
+        return mocker.patch("autosuspend.checks.systemd.next_timer_executions")
+
+    def create_instance(self, name: str) -> Check:
+        return SystemdTimer(name, re.compile(".*"))
+
+    def test_create_handles_incorrect_expressions(self) -> None:
+        with pytest.raises(ConfigurationError):
+            SystemdTimer.create("somename", config_section({"match": "(.*"}))
+
+    def test_create_raises_if_match_is_missing(self) -> None:
+        with pytest.raises(ConfigurationError):
+            SystemdTimer.create("somename", config_section())
+
+    def test_works_without_timers(self, next_timer_executions: Mock) -> None:
+        next_timer_executions.return_value = {}
+        now = datetime.now(timezone.utc)
+
+        assert SystemdTimer("foo", re.compile(".*")).check(now) is None
+
+    def test_ignores_non_matching_timers(self, next_timer_executions: Mock) -> None:
+        now = datetime.now(timezone.utc)
+        next_timer_executions.return_value = {"ignored": now}
+
+        assert SystemdTimer("foo", re.compile("needle")).check(now) is None
+
+    def test_finds_matching_timers(self, next_timer_executions: Mock) -> None:
+        pattern = "foo"
+        now = datetime.now(timezone.utc)
+        next_timer_executions.return_value = {pattern: now}
+
+        assert SystemdTimer("foo", re.compile(pattern)).check(now) is now
+
+    def test_selects_the_closest_execution_if_multiple_match(
+        self, next_timer_executions: Mock
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        next_timer_executions.return_value = {
+            "later": now + timedelta(minutes=1),
+            "matching": now,
+        }
+
+        assert SystemdTimer("foo", re.compile(".*")).check(now) is now

--- a/tests/test_checks_wakeup.py
+++ b/tests/test_checks_wakeup.py
@@ -1,8 +1,6 @@
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-import re
 import subprocess
-from unittest.mock import Mock
 
 import pytest
 from pytest_mock import MockFixture
@@ -13,7 +11,7 @@ from autosuspend.checks import (
     SevereCheckError,
     TemporaryCheckError,
 )
-from autosuspend.checks.wakeup import Command, File, Periodic, SystemdTimer
+from autosuspend.checks.wakeup import Command, File, Periodic
 
 from . import CheckTest
 from .utils import config_section
@@ -143,51 +141,3 @@ class TestPeriodic(CheckTest):
         check = Periodic("test", delta)
         now = datetime.now(timezone.utc)
         assert check.check(now) == now + delta
-
-
-class TestSystemdTimer(CheckTest):
-    @staticmethod
-    @pytest.fixture()
-    def next_timer_executions(mocker: MockFixture) -> Mock:
-        return mocker.patch("autosuspend.checks.wakeup.next_timer_executions")
-
-    def create_instance(self, name: str) -> Check:
-        return SystemdTimer(name, re.compile(".*"))
-
-    def test_create_handles_incorrect_expressions(self) -> None:
-        with pytest.raises(ConfigurationError):
-            SystemdTimer.create("somename", config_section({"match": "(.*"}))
-
-    def test_create_raises_if_match_is_missing(self) -> None:
-        with pytest.raises(ConfigurationError):
-            SystemdTimer.create("somename", config_section())
-
-    def test_works_without_timers(self, next_timer_executions: Mock) -> None:
-        next_timer_executions.return_value = {}
-        now = datetime.now(timezone.utc)
-
-        assert SystemdTimer("foo", re.compile(".*")).check(now) is None
-
-    def test_ignores_non_matching_timers(self, next_timer_executions: Mock) -> None:
-        now = datetime.now(timezone.utc)
-        next_timer_executions.return_value = {"ignored": now}
-
-        assert SystemdTimer("foo", re.compile("needle")).check(now) is None
-
-    def test_finds_matching_timers(self, next_timer_executions: Mock) -> None:
-        pattern = "foo"
-        now = datetime.now(timezone.utc)
-        next_timer_executions.return_value = {pattern: now}
-
-        assert SystemdTimer("foo", re.compile(pattern)).check(now) is now
-
-    def test_selects_the_closest_execution_if_multiple_match(
-        self, next_timer_executions: Mock
-    ) -> None:
-        now = datetime.now(timezone.utc)
-        next_timer_executions.return_value = {
-            "later": now + timedelta(minutes=1),
-            "matching": now,
-        }
-
-        assert SystemdTimer("foo", re.compile(".*")).check(now) is now

--- a/tests/test_util_systemd.py
+++ b/tests/test_util_systemd.py
@@ -1,11 +1,7 @@
 from dbus.proxies import ProxyObject
 import pytest
 
-from autosuspend.util.systemd import (
-    list_logind_sessions,
-    LogindDBusException,
-    next_timer_executions,
-)
+from autosuspend.util.systemd import list_logind_sessions, LogindDBusException
 
 
 def test_list_logind_sessions_empty(logind: ProxyObject) -> None:
@@ -21,8 +17,3 @@ def test_list_logind_sessions_empty(logind: ProxyObject) -> None:
 def test_list_logind_sessions_dbus_error() -> None:
     with pytest.raises(LogindDBusException):
         list_logind_sessions()
-
-
-@pytest.mark.skip(reason="No dbusmock implementation available")
-def test_next_timer_executions() -> None:
-    assert next_timer_executions() is not None


### PR DESCRIPTION
The systemd utils module still exists because the XOrgIdleTime check
also optionally uses systemd.