### PR TITLE
systemd: a session is also not idle if IdleHint=no

### DIFF
--- a/src/autosuspend/checks/systemd.py
+++ b/src/autosuspend/checks/systemd.py
@@ -109,7 +109,7 @@ class LogindSessionsIdle(Activity):
                 )
                 continue
 
-            if not properties["IdleHint"]:
+            if properties.get("IdleHint", False) == False:
                 return "Login session {} is not idle".format(session_id)
 
         return None


### PR DESCRIPTION
Not only is a session not idle if IdleHint is not set, it is also not
idle if its value is "no".

We are seeing that autosuspend from debian stable (3.0 IIRC) sometimes misses active sessions, i.e., session with IdleHint=no. I suspect that this could be the culprit.