### PR TITLE
fix(ical): support all versions of tzlocal

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extras_require = {
     "XPath": ["lxml", "requests"],
     "JSONPath": ["jsonpath-ng", "requests"],
     "Logind": ["dbus-python"],
-    "ical": ["requests", "icalendar", "python-dateutil", "tzlocal!=3.0"],
+    "ical": ["requests", "icalendar", "python-dateutil", "tzlocal"],
     "localfiles": ["requests-file"],
     "logactivity": ["python-dateutil", "pytz"],
     "test": [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,test-py38-psutil55-dateutil27-tzlocal2, test-py{39,310}-psutillatest-dateutillatest-tzlocallatest, integration-py{38,39,310}, mindeps, check, docs, coverage
+envlist = coverage-clean,test-py38-psutil55-dateutil27-tzlocal2, test-py{39,310}-psutillatest-dateutillatest-tzlocal{4,latest}, integration-py{38,39,310}, mindeps, check, docs, coverage
 
 [testenv]
 extras = test
@@ -11,7 +11,8 @@ deps =
     dateutil27: python-dateutil>=2.7,<2.8
     dateutillatest: python-dateutil
     tzlocal2: tzlocal<3
-    tzlocallatest: tzlocal>3
+    tzlocal4: tzlocal>3,<5
+    tzlocallatest: tzlocal>4
 commands =
     {envbindir}/python -V
     {envbindir}/python -c 'import psutil; print(psutil.__version__)'


### PR DESCRIPTION
Depending on the package version, tzlocal either returns a zoneinfo.ZoneInfo or a pytz timezone object. Provide a face method for localizing datetimes using any of the possible return types of tzlocal. This allows supporting all available tzlocal versions again.