### PR TITLE
systemd: ensure we only iterate over timers

### DIFF
--- a/src/autosuspend/checks/systemd.py
+++ b/src/autosuspend/checks/systemd.py
@@ -22,6 +22,9 @@ def next_timer_executions() -> Dict[str, datetime]:
         properties_interface = dbus.Interface(obj, "org.freedesktop.DBus.Properties")
         props = properties_interface.GetAll("org.freedesktop.systemd1.Timer")
 
+        if not props["Unit"].endswith(".timer"):
+            continue
+
         next_time: Optional[datetime] = None
         if props["NextElapseUSecRealtime"]:
             next_time = datetime.fromtimestamp(


### PR DESCRIPTION
Somehow the loop contained

```
(Pdb) p props
dbus.Dictionary({dbus.String('Unit'): dbus.String('cron-monthly.target', variant_level=1), dbus.String('TimersMonotonic'): dbus.Array([], signature=dbus.Signature('(stt)'), variant_level=1), dbus.String('TimersCalendar'): dbus.Array([dbus.Struct((dbus.String('OnCalendar'), dbus.String('*-*-01 00:00:00'), dbus.UInt64(0)), signature=None)], signature=dbus.Signature('(sst)'), variant_level=1), dbus.String('OnClockChange'): dbus.Boolean(False, variant_level=1), dbus.String('OnTimezoneChange'): dbus.Boolean(False, variant_level=1), dbus.String('NextElapseUSecRealtime'): dbus.UInt64(18446744073709551615, variant_level=1), dbus.String('NextElapseUSecMonotonic'): dbus.UInt64(18446744073709551615, variant_level=1),
```

that is, cron-montly.target, with NextElapseUSecRealtime and NextElapseUSecMonotonic set to 18446744073709551615 (UINT64_MAX).

This caused datetime.fromtimestamp() to throw a ValueError, causing the termination of autosuspend:

```
autosuspend[7204]: 2023-08-09 14:08:09,920 - autosuspend.Processor - INFO - System is idle long enough.
autosuspend[7204]: Traceback (most recent call last):
autosuspend[7204]:   File "/usr/lib/python-exec/python3.11/autosuspend", line 8, in <module>
autosuspend[7204]:     sys.exit(main())
autosuspend[7204]:              ^^^^^^
autosuspend[7204]:   File "/usr/lib/python3.11/site-packages/autosuspend/__init__.py", line 793, in main
autosuspend[7204]:     args.func(args, config)
autosuspend[7204]:   File "/usr/lib/python3.11/site-packages/autosuspend/__init__.py", line 775, in main_daemon
autosuspend[7204]:     loop(
autosuspend[7204]:   File "/usr/lib/python3.11/site-packages/autosuspend/__init__.py", line 375, in loop
autosuspend[7204]:     _do_loop_iteration(processor, woke_up_file, lock_file, lock_timeout)
autosuspend[7204]:   File "/usr/lib/python3.11/site-packages/autosuspend/__init__.py", line 340, in _do_loop_iteration
autosuspend[7204]:     processor.iteration(datetime.now(timezone.utc), just_woke_up)
autosuspend[7204]:   File "/usr/lib/python3.11/site-packages/autosuspend/__init__.py", line 283, in iteration
autosuspend[7204]:     wakeup_at = execute_wakeups(self._wakeups, timestamp, self._logger)
autosuspend[7204]:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
autosuspend[7204]:   File "/usr/lib/python3.11/site-packages/autosuspend/__init__.py", line 168, in execute_wakeups
autosuspend[7204]:     this_at = _safe_execute_wakeup(wakeup, timestamp, logger)
autosuspend[7204]:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
autosuspend[7204]:   File "/usr/lib/python3.11/site-packages/autosuspend/__init__.py", line 157, in _safe_execute_wakeup
autosuspend[7204]:     return check.check(timestamp)
autosuspend[7204]:            ^^^^^^^^^^^^^^^^^^^^^^
autosuspend[7204]:   File "/usr/lib/python3.11/site-packages/autosuspend/checks/systemd.py", line 57, in check
autosuspend[7204]:     executions = next_timer_executions()
autosuspend[7204]:                  ^^^^^^^^^^^^^^^^^^^^^^^
autosuspend[7204]:   File "/usr/lib/python3.11/site-packages/autosuspend/checks/systemd.py", line 27, in next_timer_executions
autosuspend[7204]:     next_time = datetime.fromtimestamp(
autosuspend[7204]:                 ^^^^^^^^^^^^^^^^^^^^^^^
autosuspend[7204]: ValueError: year 586524 is out of range
systemd[1]: autosuspend.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: autosuspend.service: Failed with result 'exit-code'.
```

To avoid this, we check that the unit we look at is actually a timer.