### PR TITLE
feat(logind)!: configure which session classes to process

### DIFF
--- a/doc/source/available_checks.rst
+++ b/doc/source/available_checks.rst
@@ -316,6 +316,12 @@ Options
    For instance, ``lingering`` sessions used for background programs might not be of interest.
    Default: ``active``, ``online``
 
+.. option:: classes
+
+   A comma-separated list of session classes to inspect.
+   For instance, ``greeter`` sessions used by greeters such as lightdm might not be of interest.
+   Default: ``user``
+
 Requirements
 ============
 

--- a/src/autosuspend/checks/systemd.py
+++ b/src/autosuspend/checks/systemd.py
@@ -93,12 +93,21 @@ class LogindSessionsIdle(Activity):
         types = [t.strip() for t in types]
         states = config.get("states", fallback="active,online").split(",")
         states = [t.strip() for t in states]
-        return cls(name, types, states)
+        classes = config.get("classes", fallback="user").split(",")
+        classes = [t.strip() for t in classes]
+        return cls(name, types, states, classes)
 
-    def __init__(self, name: str, types: Iterable[str], states: Iterable[str]) -> None:
+    def __init__(
+        self,
+        name: str,
+        types: Iterable[str],
+        states: Iterable[str],
+        classes: Iterable[str] = ("user"),
+    ) -> None:
         Activity.__init__(self, name)
         self._types = types
         self._states = states
+        self._classes = classes
 
     @staticmethod
     def _list_logind_sessions() -> Iterable[Tuple[str, dict]]:
@@ -119,6 +128,11 @@ class LogindSessionsIdle(Activity):
             if properties["State"] not in self._states:
                 self.logger.debug(
                     "Ignoring session because its state is %s", properties["State"]
+                )
+                continue
+            if properties["Class"] not in self._classes:
+                self.logger.debug(
+                    "Ignoring session because its class is %s", properties["Class"]
                 )
                 continue
 

--- a/tests/test_checks_systemd.py
+++ b/tests/test_checks_systemd.py
@@ -93,6 +93,14 @@ class TestLogindSessionsIdle(CheckTest):
         check = LogindSessionsIdle("test", ["not_test"], ["active", "online"])
         assert check.check() is None
 
+    def test_ignore_unknown_class(self, logind: ProxyObject) -> None:
+        logind.AddSession("c1", "seat0", 1042, "user", True)
+
+        check = LogindSessionsIdle(
+            "test", ["test"], ["active", "online"], ["nosuchclass"]
+        )
+        assert check.check() is None
+
     def test_configure_defaults(self) -> None:
         check = LogindSessionsIdle.create("name", config_section())
         assert check._types == ["tty", "x11", "wayland"]
@@ -109,6 +117,12 @@ class TestLogindSessionsIdle(CheckTest):
             "name", config_section({"states": "test, bla,foo"})
         )
         assert check._states == ["test", "bla", "foo"]
+
+    def test_configure_classes(self) -> None:
+        check = LogindSessionsIdle.create(
+            "name", config_section({"classes": "test, bla,foo"})
+        )
+        assert check._classes == ["test", "bla", "foo"]
 
     @pytest.mark.usefixtures("_logind_dbus_error")
     def test_dbus_error(self) -> None:


### PR DESCRIPTION
logind sessions have different classes. So far, all classes of logind sessions were taken into account. However, this might include greeter sessions by tools such as lightdm. With this commit, a new config option for the LogindSessionIdle check allows configuring which classes of sessions to look at. The default value restricts processing to users sessions as a sensible default.

BREAKING CHANGE: LogindSessionIdle now only processes sessions of type "user" by default. Use the new configuration option classes to also include other types in case you need to include them in the checks.

Fixes: #366