### PR TITLE
build!: modernize supported Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - name: Clone repo
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.11"
       - name: Install native dependencies
         run: sudo apt-get update && sudo apt-get -y install libdbus-1-dev libgirepository1.0-dev
       - name: Cache Python packages
@@ -47,10 +47,10 @@ jobs:
     steps:
       - name: Clone repo
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.11"
       - name: Install native dependencies
         run: sudo apt-get update && sudo apt-get -y install libdbus-1-dev libgirepository1.0-dev plantuml
       - name: Cache Python packages
@@ -93,7 +93,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - name: Clone repo

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
-envlist = coverage-clean,test-py38-psutil55-dateutil27-tzlocal2, test-py{39,310}-psutillatest-dateutillatest-tzlocal{4,latest}, integration-py{38,39,310}, mindeps, check, docs, coverage
+envlist = coverage-clean,test-py39-psutil58-dateutil28-tzlocal2, test-py{310,311}-psutillatest-dateutillatest-tzlocal{4,latest}, integration-py{39,310,311}, mindeps, check, docs, coverage
 
 [testenv]
 extras = test
 setenv =
     COVERAGE_FILE = ./.coverage.{envname}
 deps =
-    psutil55: psutil>=5.5,<5.6
+    psutil58: psutil>=5.8,<5.9
     psutillatest: psutil
-    dateutil27: python-dateutil>=2.7,<2.8
+    dateutil28: python-dateutil>=2.8,<2.9
     dateutillatest: python-dateutil
     tzlocal2: tzlocal<3
     tzlocal4: tzlocal>3,<5
@@ -28,7 +28,7 @@ commands = coverage erase
 depends =
 
 [testenv:coverage]
-depends = test-py38-psutil{55,latest}-dateutil{27,latest}, test-py39-psutillatest-dateutillatest, test-py310-psutillatest-dateutillatest, integration-py{38,39,310}
+depends = test-py39-psutil{58,latest}-dateutil{28,latest}, test-py{310,311}-psutillatest-dateutillatest, integration-py{39,310,311}
 deps =
     coverage
 skip_install = true
@@ -60,13 +60,13 @@ commands =
     {envbindir}/mypy src tests
 
 [testenv:docs]
-basepython = python3.9
+basepython = python3.11
 depends =
 deps = -rrequirements-doc.txt
 commands = {envbindir}/sphinx-build -W -b html -d {envtmpdir}/doctrees doc/source {envtmpdir}/html
 
 [gh-actions]
 python =
-    3.8: py38, coverage
     3.9: py39, coverage
     3.10: py310, coverage
+    3.11: py311, coverage


### PR DESCRIPTION
Adds Python 3.11 into tests and deprecates Python 3.8 support, which is not part of Debian oldstable anymore.

BREAKING CHANGE: Python 3.8 has been deprecated and is not officially
  supported anymore.