### PR TITLE
KodiIdleTime: Remove surplus brace

### DIFF
--- a/src/autosuspend/checks/kodi.py
+++ b/src/autosuspend/checks/kodi.py
@@ -79,7 +79,7 @@ class KodiIdleTime(NetworkMixin, Activity):
 
     def __init__(self, name: str, url: str, idle_time: int, **kwargs: Any) -> None:
         request = url + (
-            '?request={{"jsonrpc": "2.0", "id": 1, '
+            '?request={"jsonrpc": "2.0", "id": 1, '
             '"method": "XBMC.GetInfoBooleans",'
             f'"params": {{"booleans": ["System.IdleTime({idle_time})"]}}}}'
         )


### PR DESCRIPTION
This commit fixes a syntax error in the request sent to Kodi in the KodiIdleTime check. A sample request from autosuspend is following:
`{{"jsonrpc": "2.0", "id": 1, "method": "XBMC.GetInfoBooleans","params": {"booleans": ["System.IdleTime(300)"]}}`

It has a surplus opening curly brace at the beginning, leading Kodi to ignore the request with the following log entry:
`error <general>: JSONRPC: Failed to parse [the above request]`

This leads to the following exception in autosuspend:
```
autosuspend.Processor - WARNING - Check kodi-browsing[class=KodiIdleTime] failed. Ignoring... Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/autosuspend/checks/kodi.py", line 93, in check
    if not reply["result"][f"System.IdleTime({self._idle_time})"]:
           ~~~~~^^^^^^^^^^
KeyError: 'result'
```