### PR TITLE
feat(systemd): automatically enable/disable suspend hook

### DIFF
--- a/data/autosuspend.service
+++ b/data/autosuspend.service
@@ -8,3 +8,4 @@ ExecStart=/usr/bin/autosuspend -l /etc/autosuspend-logging.conf daemon
 
 [Install]
 WantedBy=multi-user.target
+Also=autosuspend-detect-suspend.service

--- a/doc/source/systemd_integration.rst
+++ b/doc/source/systemd_integration.rst
@@ -19,11 +19,6 @@ To start |project_program| via `systemd`_, execute:
 .. code-block:: bash
 
    systemctl enable autosuspend.service
-   systemctl enable autosuspend-detect-suspend.service
-
-.. note::
-
-   Do not forget the second ``enable`` call to ensure that wake ups are configured even if the system is manually placed into suspend.
 
 To start |project_program| automatically at system start, execute:
 


### PR DESCRIPTION
Declares the autosuspend-detect-suspend.service in the Also section of the autosuspend systemd unit. That way, the suspend unit is enabled/disabled together with the main unit and users don't have to remember activating/deactivating this unit.

Cf.: #625