### PR TITLE
Collect optional 'match' from config and use it to parse ical

### DIFF
--- a/doc/source/available_checks.rst
+++ b/doc/source/available_checks.rst
@@ -39,6 +39,12 @@ Options
    Optional password to use for authenticating at a server requiring authentication.
    If used, also a user name must be provided.
 
+.. option:: match
+
+   Optional string used to match the calendar summary.
+   If used, it will remove calendar events that don't _contain_ this string.
+
+
 Requirements
 ============
 

--- a/doc/source/available_wakeups.rst
+++ b/doc/source/available_wakeups.rst
@@ -45,6 +45,11 @@ Options
 
    Timeout for executed requests in seconds. Default: 5.
 
+.. option:: match
+
+   Optional string used to match the calendar summary.
+   If used, it will remove calendar events that don't _contain_ this string.
+
 
 Requirements
 ============

--- a/src/autosuspend/checks/ical.py
+++ b/src/autosuspend/checks/ical.py
@@ -258,7 +258,7 @@ def _extract_events_from_component(
 
 
 def list_calendar_events(
-    data: IO[bytes], start_at: datetime, end_at: datetime, match: str
+    data: IO[bytes], start_at: datetime, end_at: datetime, match: str | None
 ) -> Sequence[CalendarEvent]:
     """List all relevant calendar events in the provided interval.
 


### PR DESCRIPTION
Check the configuration for an optional string: 'match'

If the string exists anywhere in the summary, then the event is valid.
If the string is missing in the config entirely, then all events are valid

See #340 