### PR TITLE
refactor(deps): remove pytz, require tzdata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras_require = {
     "Logind": ["dbus-python"],
     "ical": ["requests", "icalendar", "python-dateutil", "tzlocal"],
     "localfiles": ["requests-file"],
-    "logactivity": ["python-dateutil", "pytz"],
+    "logactivity": ["python-dateutil", "tzdata"],
     "test": [
         "pytest",
         "pytest-cov",

--- a/src/autosuspend/checks/logs.py
+++ b/src/autosuspend/checks/logs.py
@@ -4,10 +4,10 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import re
 from re import Pattern
+from zoneinfo import ZoneInfo
 
 from dateutil.parser import parse
 from dateutil.utils import default_tzinfo
-import pytz
 
 from . import Activity, ConfigurationError, TemporaryCheckError
 
@@ -22,7 +22,7 @@ class LastLogActivity(Activity):
                 re.compile(config["pattern"]),
                 timedelta(minutes=config.getint("minutes", fallback=10)),
                 config.get("encoding", "ascii"),
-                pytz.timezone(config.get("timezone", "UTC")),  # type: ignore
+                ZoneInfo(config.get("timezone", "UTC")),  # type: ignore
             )
         except KeyError as error:
             raise ConfigurationError(

--- a/src/autosuspend/util/datetime.py
+++ b/src/autosuspend/util/datetime.py
@@ -6,4 +6,6 @@ def is_aware(dt: datetime) -> bool:
 
 
 def to_tz_unaware(dt: datetime, tz: tzinfo | None) -> datetime:
-    return dt.astimezone(tz).replace(tzinfo=None)
+    """Convert a datetime to the given timezone and return a naive datetime (no tzinfo)."""
+    dt = dt.replace(tzinfo=tz) if dt.tzinfo is None else dt.astimezone(tz)
+    return dt.replace(tzinfo=None)

--- a/tests/test_checks_ical.py
+++ b/tests/test_checks_ical.py
@@ -3,8 +3,8 @@ from datetime import timedelta
 from pathlib import Path
 
 from dateutil import parser
-from dateutil.tz import tzlocal
 from freezegun import freeze_time
+import tzlocal
 
 from autosuspend.checks import Check
 from autosuspend.checks.ical import (
@@ -142,11 +142,11 @@ class TestListCalendarEvents:
 
     def test_floating_time(self, datadir: Path) -> None:
         with (datadir / "floating.ics").open("rb") as f:
-            start = parser.parse("2018-06-09 00:00:00 +0200")
+            tzinfo = {"LOCAL": tzlocal.get_localzone()}
+
+            start = parser.parse("2018-06-09 00:00:00 LOCAL", tzinfos=tzinfo)
             end = start + timedelta(weeks=1)
             events = list_calendar_events(f, start, end)
-
-            tzinfo = {"LOCAL": tzlocal()}
 
             expected = [
                 (
@@ -180,11 +180,11 @@ class TestListCalendarEvents:
 
     def test_floating_time_other_dst(self, datadir: Path) -> None:
         with (datadir / "floating.ics").open("rb") as f:
-            start = parser.parse("2018-12-09 00:00:00 +0200")
+            tzinfo = {"LOCAL": tzlocal.get_localzone()}
+
+            start = parser.parse("2018-12-09 00:00:00 LOCAL", tzinfos=tzinfo)
             end = start + timedelta(weeks=1)
             events = list_calendar_events(f, start, end)
-
-            tzinfo = {"LOCAL": tzlocal()}
 
             expected = [
                 (

--- a/tests/test_checks_logs.py
+++ b/tests/test_checks_logs.py
@@ -1,10 +1,10 @@
 from datetime import timedelta, timezone
 from pathlib import Path
 import re
+from zoneinfo import ZoneInfo
 
 from freezegun import freeze_time
 import pytest
-import pytz
 
 from autosuspend.checks import ConfigurationError, TemporaryCheckError
 from autosuspend.checks.logs import LastLogActivity
@@ -209,7 +209,7 @@ class TestLastLogActivity(CheckTest):
         assert created.pattern == re.compile(r"^foo(.*)bar$")
         assert created.delta == timedelta(minutes=42)
         assert created.encoding == "utf-8"
-        assert created.default_timezone == pytz.timezone("Europe/Berlin")
+        assert created.default_timezone == ZoneInfo("Europe/Berlin")
 
     def test_create_handles_pattern_errors(self) -> None:
         with pytest.raises(ConfigurationError):


### PR DESCRIPTION
pytz has become obsolete nowadays. However, we might need tzdata on some systems, which is a new dependency maintained by PSF.

BREAKING CHANGE: new optional dependency tzdata when doing log parsing