### PR TITLE
feat: filter calendar events by summary regex

### DIFF
--- a/src/autosuspend/checks/ical.py
+++ b/src/autosuspend/checks/ical.py
@@ -1,3 +1,5 @@
+import configparser
+import re
 from collections.abc import Iterable, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
@@ -13,6 +15,7 @@ from dateutil.rrule import rrule, rruleset, rrulestr
 
 from . import Activity, Wakeup
 from .util import NetworkMixin
+from ..config import ParameterType, config_param
 from ..util.datetime import is_aware, to_tz_unaware
 
 
@@ -250,7 +253,7 @@ def _extract_events_from_component(
 
 
 def list_calendar_events(
-    data: IO[bytes], start_at: datetime, end_at: datetime
+    data: IO[bytes], start_at: datetime, end_at: datetime, match: str = ".*"
 ) -> Sequence[CalendarEvent]:
     """List all relevant calendar events in the provided interval.
 
@@ -261,6 +264,9 @@ def list_calendar_events(
             include events overlapping with this time (inclusive)
         end_at:
             do not include events that start after or exactly at this time
+        match:
+            a regular expression; only events whose summary matches are
+            included. Defaults to matching all events.
     """
     # some useful notes:
     # * end times and dates are non-inclusive for ical events
@@ -276,15 +282,22 @@ def list_calendar_events(
 
     events = []
     for component in cast("list[icalendar.Event]", calendar.walk("VEVENT")):
-        events.extend(
-            _extract_events_from_component(
-                component, recurring_changes, start_at, end_at
+        if re.search(match, str(component.get("summary", ""))):
+            events.extend(
+                _extract_events_from_component(
+                    component, recurring_changes, start_at, end_at
+                )
             )
-        )
 
     return sorted(events, key=lambda e: e.start)
 
 
+@config_param(
+    "match",
+    ParameterType.STRING,
+    "A regular expression matched against the summary of each calendar event. Only events whose summary matches are considered active. Defaults to matching all events.",
+    default=".*",
+)
 class ActiveCalendarEvent(NetworkMixin, Activity):
     """Check for active calendar events.
 
@@ -301,15 +314,26 @@ class ActiveCalendarEvent(NetworkMixin, Activity):
     * `tzlocal`_
     """
 
-    def __init__(self, name: str, **kwargs: Any) -> None:
+    @classmethod
+    def create(
+        cls, name: str, config: configparser.SectionProxy
+    ) -> "ActiveCalendarEvent":
+        kwargs = NetworkMixin.collect_init_args(config)
+        kwargs["match"] = config.get("match", fallback=".*")
+        return cls(name, **kwargs)
+
+    def __init__(self, name: str, match: str = ".*", **kwargs: Any) -> None:
         NetworkMixin.__init__(self, **kwargs)
         Activity.__init__(self, name)
+        self._match = match
 
     def check(self) -> str | None:
         response = self.request()
         start = datetime.now(UTC)
         end = start + timedelta(minutes=1)
-        events = list_calendar_events(BytesIO(response.content), start, end)
+        events = list_calendar_events(
+            BytesIO(response.content), start, end, self._match
+        )
         self.logger.debug(
             "Listing active events between %s and %s returned %s events",
             start,
@@ -322,6 +346,12 @@ class ActiveCalendarEvent(NetworkMixin, Activity):
             return None
 
 
+@config_param(
+    "match",
+    ParameterType.STRING,
+    "A regular expression matched against the summary of each calendar event. Only events whose summary matches are used to determine the next wake up time. Defaults to matching all events.",
+    default=".*",
+)
 class Calendar(NetworkMixin, Wakeup):
     """Determine wake up times from calendar events.
 
@@ -339,15 +369,24 @@ class Calendar(NetworkMixin, Wakeup):
     * `tzlocal`_
     """
 
-    def __init__(self, name: str, **kwargs: Any) -> None:
+    @classmethod
+    def create(cls, name: str, config: configparser.SectionProxy) -> "Calendar":
+        kwargs = NetworkMixin.collect_init_args(config)
+        kwargs["match"] = config.get("match", fallback=".*")
+        return cls(name, **kwargs)
+
+    def __init__(self, name: str, match: str = ".*", **kwargs: Any) -> None:
         NetworkMixin.__init__(self, **kwargs)
         Wakeup.__init__(self, name)
+        self._match = match
 
     def check(self, timestamp: datetime) -> datetime | None:
         response = self.request()
 
         end = timestamp + timedelta(weeks=6 * 4)
-        events = list_calendar_events(BytesIO(response.content), timestamp, end)
+        events = list_calendar_events(
+            BytesIO(response.content), timestamp, end, self._match
+        )
         # Filter out currently active events. They are not our business.
         events = [e for e in events if e.start >= timestamp]
 

--- a/tests/test_checks_ical.py
+++ b/tests/test_checks_ical.py
@@ -401,6 +401,37 @@ class TestListCalendarEvents:
             assert expected_start_times == [e.start for e in events]
 
 
+class TestListCalendarEventsMatch:
+    def test_default_matches_all(self, datadir: Path) -> None:
+        start = parser.parse("20040401T090000Z")
+        end = parser.parse("20040701T090000Z")
+        with (datadir / "multiple.ics").open("rb") as f:
+            events = list_calendar_events(f, start, end)
+        assert len(events) == 2
+
+    def test_matching_regex_includes_event(self, datadir: Path) -> None:
+        start = parser.parse("20040401T090000Z")
+        end = parser.parse("20040701T090000Z")
+        with (datadir / "multiple.ics").open("rb") as f:
+            events = list_calendar_events(f, start, end, match="early")
+        assert len(events) == 1
+        assert events[0].summary == "early-event"
+
+    def test_non_matching_regex_excludes_all(self, datadir: Path) -> None:
+        start = parser.parse("20040401T090000Z")
+        end = parser.parse("20040701T090000Z")
+        with (datadir / "multiple.ics").open("rb") as f:
+            events = list_calendar_events(f, start, end, match="no-such-event")
+        assert len(events) == 0
+
+    def test_regex_is_search_not_fullmatch(self, datadir: Path) -> None:
+        start = parser.parse("20040401T090000Z")
+        end = parser.parse("20040701T090000Z")
+        with (datadir / "multiple.ics").open("rb") as f:
+            events = list_calendar_events(f, start, end, match="event")
+        assert len(events) == 2
+
+
 class TestActiveCalendarEvent(CheckTest):
     def create_instance(self, name: str) -> Check:
         return ActiveCalendarEvent(name, url="asdfasdf", timeout=5)
@@ -463,6 +494,25 @@ class TestActiveCalendarEvent(CheckTest):
         assert check._username == "user"
         assert check._password == "pass"
         assert check._timeout == 3
+        assert check._match == ".*"
+
+    def test_create_with_match(self) -> None:
+        check: ActiveCalendarEvent = ActiveCalendarEvent.create(
+            "name",
+            config_section({"url": "foobar", "match": "important"}),
+        )
+        assert check._match == "important"
+
+    def test_match_filters_events(
+        self, datadir: Path, serve_file: Callable[[Path], str]
+    ) -> None:
+        result = ActiveCalendarEvent(
+            "test",
+            url=serve_file(datadir / "long-event.ics"),
+            timeout=3,
+            match="no-such-event",
+        ).check()
+        assert result is None
 
 
 class TestCalendar(CheckTest):
@@ -486,6 +536,28 @@ class TestCalendar(CheckTest):
         assert check._username == "user"
         assert check._password == "pass"
         assert check._timeout == 42
+        assert check._match == ".*"
+
+    def test_create_with_match(self) -> None:
+        check: Calendar = Calendar.create(
+            "name",
+            config_section({"url": "url", "match": "important"}),
+        )
+        assert check._match == "important"
+
+    def test_match_filters_events(
+        self, datadir: Path, serve_file: Callable[[Path], str]
+    ) -> None:
+        timestamp = parser.parse("20040605T090000Z")
+        assert (
+            Calendar(
+                "test",
+                url=serve_file(datadir / "old-event.ics"),
+                timeout=3,
+                match="no-such-event",
+            ).check(timestamp)
+            is None
+        )
 
     def test_empty(self, datadir: Path, serve_file: Callable[[Path], str]) -> None:
         timestamp = parser.parse("20050605T130000Z")


### PR DESCRIPTION
Add an optional 'match' config parameter to ActiveCalendarEvent and Calendar. The value is a regular expression matched against each event's summary using re.search. Only events whose summary matches are considered active or used to schedule a wake up. The parameter defaults to '.*' so all events continue to match when it is not set, preserving the existing behaviour.

The match parameter is declared via @config_param on both classes so it appears in the schema output and the generated documentation.

Fixes #340
Replaces #649 