### PR TITLE
feat: wake up before scheduled systemd shutdowns/reboots

### DIFF
--- a/src/autosuspend/checks/systemd.py
+++ b/src/autosuspend/checks/systemd.py
@@ -9,7 +9,11 @@ import dbus
 
 from . import Activity, ConfigurationError, TemporaryCheckError, Wakeup
 from ..config import ParameterType, config_param
-from ..util.systemd import LogindDBusException, list_logind_sessions
+from ..util.systemd import (
+    LogindDBusException,
+    get_scheduled_shutdown,
+    list_logind_sessions,
+)
 
 _UINT64_MAX = 18446744073709551615
 
@@ -84,6 +88,57 @@ class SystemdTimer(Wakeup):
             return min(matching_executions)
         except ValueError:
             return None
+
+
+@config_param(
+    "delta",
+    ParameterType.FLOAT,
+    "Number of seconds before the scheduled shutdown/reboot at which the "
+    "system should already be running so that the scheduled action can "
+    "actually execute.",
+    default=180,
+    minimum=0,
+)
+class SystemdScheduledShutdown(Wakeup):
+    """Check for a pending systemd scheduled shutdown, reboot, halt or kexec.
+
+    Ensures that the system is active shortly before an action scheduled via
+    ``shutdown -r +10``, ``systemctl poweroff --when=...`` or similar is due,
+    as reported by the ``ScheduledShutdown`` property of `logind`_. Despite the
+    property's name, this also covers reboots, halts and kexecs. Scheduled
+    actions of type ``dry-reboot`` or ``dry-poweroff`` (created via
+    ``--dry-run``), which never actually execute, are ignored.
+    """
+
+    @classmethod
+    def create(cls: type[Self], name: str, config: configparser.SectionProxy) -> Self:
+        try:
+            return cls(name, config.getfloat("delta", fallback=180))
+        except ValueError as error:
+            raise ConfigurationError(str(error)) from error
+
+    def __init__(self, name: str, delta: float) -> None:
+        Wakeup.__init__(self, name)
+        self._delta = delta
+
+    def check(self, timestamp: datetime) -> datetime | None:  # noqa: ARG002
+        shutdown_type, when = self._get_scheduled_shutdown()
+
+        if not shutdown_type or when == 0 or shutdown_type.startswith("dry-"):
+            return None
+
+        scheduled_at = datetime.fromtimestamp(when / 1000000, tz=UTC)
+        self.logger.info(
+            "Scheduling wakeup for upcoming %s at %s", shutdown_type, scheduled_at
+        )
+        return scheduled_at - timedelta(seconds=self._delta)
+
+    @staticmethod
+    def _get_scheduled_shutdown() -> tuple[str, int]:
+        try:
+            return get_scheduled_shutdown()
+        except LogindDBusException as error:
+            raise TemporaryCheckError(error) from error
 
 
 @config_param(

--- a/src/autosuspend/checks/wakeup.py
+++ b/src/autosuspend/checks/wakeup.py
@@ -5,7 +5,7 @@ from contextlib import suppress
 from .command import CommandWakeup as Command  # noqa
 from .linux import File  # noqa
 from .stub import Periodic  # noqa
-from .systemd import SystemdTimer  # noqa
+from .systemd import SystemdScheduledShutdown, SystemdTimer  # noqa
 
 with suppress(ModuleNotFoundError):
     from .ical import Calendar  # noqa

--- a/src/autosuspend/util/systemd.py
+++ b/src/autosuspend/util/systemd.py
@@ -39,6 +39,36 @@ def list_logind_sessions() -> Iterable[tuple[str, dict]]:
     return results
 
 
+def get_scheduled_shutdown() -> tuple[str, int]:
+    """Get the currently scheduled systemd shutdown/reboot, if any.
+
+    Reads the ``ScheduledShutdown`` property of the `logind`_ manager, which is
+    set e.g. by ``shutdown -r +10`` or ``systemctl poweroff --when=...``. Despite
+    its name, this property also covers reboots, halts and kexecs.
+
+    Returns:
+        tuple of (type, when): ``type`` is the shutdown type such as
+        ``reboot``, ``poweroff``, ``dry-reboot``, ``dry-poweroff``, ``halt`` or
+        ``kexec``, or the empty string if nothing is scheduled. ``when`` is the
+        scheduled time in microseconds since the epoch, or 0 if nothing is
+        scheduled.
+
+    Raises:
+        LogindDBusException: If communication with logind fails.
+    """
+    try:
+        bus = _get_bus()
+        login1 = bus.get_object("org.freedesktop.login1", "/org/freedesktop/login1")
+        properties_interface = dbus.Interface(login1, "org.freedesktop.DBus.Properties")
+        shutdown_type, when = properties_interface.Get(
+            "org.freedesktop.login1.Manager", "ScheduledShutdown"
+        )
+    except dbus.exceptions.DBusException as error:
+        raise LogindDBusException(error) from error
+
+    return str(shutdown_type), int(when)
+
+
 def has_inhibit_lock() -> bool:
     """Check if there are any blocking inhibit locks that prevent sleep.
 

--- a/tests/test_checks_systemd.py
+++ b/tests/test_checks_systemd.py
@@ -9,9 +9,11 @@ from pytest_mock import MockerFixture
 from autosuspend.checks import Check, ConfigurationError, TemporaryCheckError
 from autosuspend.checks.systemd import (
     LogindSessionsIdle,
+    SystemdScheduledShutdown,
     SystemdTimer,
     next_timer_executions,
 )
+from autosuspend.util.systemd import LogindDBusException
 
 from . import CheckTest
 from .utils import config_section
@@ -68,6 +70,65 @@ class TestSystemdTimer(CheckTest):
         }
 
         assert SystemdTimer("foo", re.compile(".*")).check(now) is now
+
+
+class TestSystemdScheduledShutdown(CheckTest):
+    def create_instance(self, name: str) -> Check:
+        return SystemdScheduledShutdown(name, 180)
+
+    def test_create_default(self) -> None:
+        check = SystemdScheduledShutdown.create("name", config_section())
+        assert check._delta == 180
+
+    def test_create_custom_delta(self) -> None:
+        check = SystemdScheduledShutdown.create(
+            "name", config_section({"delta": "300"})
+        )
+        assert check._delta == 300
+
+    def test_create_invalid_delta(self) -> None:
+        with pytest.raises(ConfigurationError):
+            SystemdScheduledShutdown.create(
+                "name", config_section({"delta": "not-a-number"})
+            )
+
+    def test_nothing_scheduled(self, mocker: MockerFixture) -> None:
+        mocker.patch(
+            "autosuspend.checks.systemd.get_scheduled_shutdown",
+            return_value=("", 0),
+        )
+        assert SystemdScheduledShutdown("name", 180).check(datetime.now(UTC)) is None
+
+    @pytest.mark.parametrize("shutdown_type", ["reboot", "poweroff", "halt", "kexec"])
+    def test_shutdown_scheduled(
+        self, mocker: MockerFixture, shutdown_type: str
+    ) -> None:
+        scheduled = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        mocker.patch(
+            "autosuspend.checks.systemd.get_scheduled_shutdown",
+            return_value=(shutdown_type, int(scheduled.timestamp() * 1_000_000)),
+        )
+        result = SystemdScheduledShutdown("name", 180).check(datetime.now(UTC))
+        assert result == scheduled - timedelta(seconds=180)
+
+    @pytest.mark.parametrize("shutdown_type", ["dry-reboot", "dry-poweroff"])
+    def test_dry_run_ignored(self, mocker: MockerFixture, shutdown_type: str) -> None:
+        scheduled = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        mocker.patch(
+            "autosuspend.checks.systemd.get_scheduled_shutdown",
+            return_value=(shutdown_type, int(scheduled.timestamp() * 1_000_000)),
+        )
+        assert SystemdScheduledShutdown("name", 180).check(datetime.now(UTC)) is None
+
+    def test_dbus_error_becomes_temporary_check_error(
+        self, mocker: MockerFixture
+    ) -> None:
+        mocker.patch(
+            "autosuspend.checks.systemd.get_scheduled_shutdown",
+            side_effect=LogindDBusException("test"),
+        )
+        with pytest.raises(TemporaryCheckError):
+            SystemdScheduledShutdown("name", 180).check(datetime.now(UTC))
 
 
 class TestLogindSessionsIdle(CheckTest):

--- a/tests/test_util_systemd.py
+++ b/tests/test_util_systemd.py
@@ -1,8 +1,10 @@
+import dbus
 import pytest
 from dbus.proxies import ProxyObject
 
 from autosuspend.util.systemd import (
     LogindDBusException,
+    get_scheduled_shutdown,
     has_inhibit_lock,
     list_logind_sessions,
 )
@@ -64,3 +66,29 @@ class TestHasInhibitLock:
     def test_dbus_error(self) -> None:
         with pytest.raises(LogindDBusException):
             has_inhibit_lock()
+
+
+class TestGetScheduledShutdown:
+    def test_nothing_scheduled(self, logind: ProxyObject) -> None:
+        logind.AddProperty(
+            "org.freedesktop.login1.Manager",
+            "ScheduledShutdown",
+            dbus.Struct((dbus.String(""), dbus.UInt64(0)), signature="st"),
+        )
+        assert get_scheduled_shutdown() == ("", 0)
+
+    def test_reboot_scheduled(self, logind: ProxyObject) -> None:
+        logind.AddProperty(
+            "org.freedesktop.login1.Manager",
+            "ScheduledShutdown",
+            dbus.Struct(
+                (dbus.String("reboot"), dbus.UInt64(1735689600000000)),
+                signature="st",
+            ),
+        )
+        assert get_scheduled_shutdown() == ("reboot", 1735689600000000)
+
+    @pytest.mark.usefixtures("_logind_dbus_error")
+    def test_dbus_error(self) -> None:
+        with pytest.raises(LogindDBusException):
+            get_scheduled_shutdown()


### PR DESCRIPTION
Adds a new wakeup check called SystemdScheduledShutdown which allows scheduling wake ups before a scheduled systemd event such as a reboot or shutdown of the system.

Fixes: #253